### PR TITLE
fix: findWithFallback result types

### DIFF
--- a/packages/zod-firebase-admin/src/collection/factory/multi-document-collection-factory.ts
+++ b/packages/zod-firebase-admin/src/collection/factory/multi-document-collection-factory.ts
@@ -25,6 +25,13 @@ export type SchemaFallbackValue<
   ? Except<Extract<SchemaDocumentInput<TCollectionSchema>, { _id: TDocumentId }>, '_id'>
   : SchemaDocumentInput<TCollectionSchema>
 
+export type SchemaFallbackOutputDocument<
+  TCollectionSchema extends CollectionSchema,
+  TDocumentId extends string = string,
+> = TCollectionSchema extends { includeDocumentIdForZod: true }
+  ? Except<Extract<SchemaDocumentOutput<TCollectionSchema>, { _id: TDocumentId }>, '_id'>
+  : SchemaDocumentOutput<TCollectionSchema>
+
 export interface MultiDocumentCollectionFactory<TCollectionSchema extends CollectionSchema>
   extends SchemaFirestoreFactory<TCollectionSchema> {
   findById<Options extends MetaOutputOptions>(
@@ -43,7 +50,7 @@ export interface MultiDocumentCollectionFactory<TCollectionSchema extends Collec
     this: void,
     id: TDocumentId,
     fallback: SchemaFallbackValue<TCollectionSchema, TDocumentId>,
-  ): Promise<SchemaDocumentOutput<TCollectionSchema>>
+  ): Promise<SchemaFallbackOutputDocument<TCollectionSchema>>
 
   add(
     this: void,
@@ -96,18 +103,18 @@ export const multiDocumentCollectionFactory = <TCollectionSchema extends Collect
     const doc = await firestoreFactory.read.doc(id).get()
     if (doc.exists) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      return doc.data()!
+      return doc.data()! as SchemaFallbackOutputDocument<TCollectionSchema, TDocumentId>
     }
     if (schema.includeDocumentIdForZod) {
       return schema.zod.parse({
         _id: id,
         ...(fallback as DocumentData),
-      }) as SchemaDocumentOutput<TCollectionSchema>
+      }) as SchemaFallbackOutputDocument<TCollectionSchema, TDocumentId>
     }
     return {
       _id: id,
       ...schema.zod.parse(fallback),
-    } as SchemaDocumentOutput<TCollectionSchema>
+    } as SchemaFallbackOutputDocument<TCollectionSchema, TDocumentId>
   },
   add: async (data) => firestoreFactory.write.collection().add(data),
   create: async (id, data) => firestoreFactory.write.doc(id).create(data),

--- a/packages/zod-firebase-admin/src/collection/factory/single-document-collection-factory.ts
+++ b/packages/zod-firebase-admin/src/collection/factory/single-document-collection-factory.ts
@@ -20,7 +20,11 @@ import {
   type SchemaWriteDocumentReference,
 } from '../../schema'
 
-import { multiDocumentCollectionFactory, type SchemaFallbackValue } from './multi-document-collection-factory'
+import {
+  multiDocumentCollectionFactory,
+  type SchemaFallbackOutputDocument,
+  type SchemaFallbackValue,
+} from './multi-document-collection-factory'
 
 export interface SingleDocumentCollectionFactory<TCollectionSchema extends CollectionSchema> {
   readonly singleDocumentKey: string
@@ -49,7 +53,7 @@ export interface SingleDocumentCollectionFactory<TCollectionSchema extends Colle
   findWithFallback(
     this: void,
     fallback: SchemaFallbackValue<TCollectionSchema>,
-  ): Promise<SchemaDocumentOutput<TCollectionSchema>>
+  ): Promise<SchemaFallbackOutputDocument<TCollectionSchema>>
 
   create(this: void, data: WithFieldValue<SchemaDocumentInput<TCollectionSchema>>): Promise<WriteResult>
 
@@ -97,8 +101,7 @@ export const singleDocumentCollectionFactory = <TCollectionSchema extends Collec
     },
     find: <Options extends MetaOutputOptions>(options?: Options) => findById(singleDocumentKey, options),
     findOrThrow: <Options extends MetaOutputOptions>(options?: Options) => findByIdOrThrow(singleDocumentKey, options),
-    findWithFallback: (fallback: SchemaFallbackValue<TCollectionSchema>) =>
-      findByIdWithFallback(singleDocumentKey, fallback),
+    findWithFallback: (fallback) => findByIdWithFallback(singleDocumentKey, fallback),
     write: {
       ...write,
       doc: () => write.doc(singleDocumentKey),

--- a/packages/zod-firebase/src/collection/factory/single-document-collection-factory.ts
+++ b/packages/zod-firebase/src/collection/factory/single-document-collection-factory.ts
@@ -13,7 +13,11 @@ import {
   type SchemaWriteDocumentReference,
 } from '../../schema'
 
-import { multiDocumentCollectionFactory, type SchemaFallbackValue } from './multi-document-collection-factory'
+import {
+  multiDocumentCollectionFactory,
+  type SchemaFallbackOutputDocument,
+  type SchemaFallbackValue,
+} from './multi-document-collection-factory'
 
 export interface SingleDocumentCollectionFactory<TCollectionSchema extends CollectionSchema> {
   readonly singleDocumentKey: string
@@ -42,7 +46,7 @@ export interface SingleDocumentCollectionFactory<TCollectionSchema extends Colle
   findWithFallback(
     this: void,
     fallback: SchemaFallbackValue<TCollectionSchema>,
-  ): Promise<SchemaDocumentOutput<TCollectionSchema>>
+  ): Promise<SchemaFallbackOutputDocument<TCollectionSchema>>
 
   set(this: void, data: WithFieldValue<SchemaDocumentInput<TCollectionSchema>>): Promise<void>
 
@@ -83,8 +87,7 @@ export const singleDocumentCollectionFactory = <TCollectionSchema extends Collec
     },
     find: <Options extends MetaOutputOptions>(options?: Options) => findById(singleDocumentKey, options),
     findOrThrow: <Options extends MetaOutputOptions>(options?: Options) => findByIdOrThrow(singleDocumentKey, options),
-    findWithFallback: (fallback: SchemaFallbackValue<TCollectionSchema>) =>
-      findByIdWithFallback(singleDocumentKey, fallback),
+    findWithFallback: (fallback) => findByIdWithFallback(singleDocumentKey, fallback),
     write: {
       ...write,
       doc: () => write.doc(singleDocumentKey),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved TypeScript typings for fallback reads: output now conditionally omits the _id field when document IDs are included automatically.
- Refactor
  - Updated return types for findByIdWithFallback and findWithFallback to a new conditional output type for clearer, safer typings.
  - Unified typing across single- and multi-document helpers; behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->